### PR TITLE
ESWE-1083 - update allow list for external NFN users

### DIFF
--- a/helm_deploy/hmpps-jobs-board-ui/values.yaml
+++ b/helm_deploy/hmpps-jobs-board-ui/values.yaml
@@ -56,7 +56,7 @@ generic-service:
 
   allowlist:
     groups:
-      - internal
+      - digital_staff_and_mojo
 
 generic-prometheus-alerts:
   targetApplication: hmpps-jobs-board-ui


### PR DESCRIPTION
For security, our preprod env allows whitelisted IP addresses, so they're available to users at the NFN users on MOJ devices.

## Changes in this PR

This restricts access to the site to IPs in the following group only:
  - digital_staff_and_mojo

The IPs are listed in [a config file in another repo](https://github.com/ministryofjustice/hmpps-ip-allowlists/blob/main/ip-allowlist-groups.yaml), then published as environment variables in the `hmpps-common-vars` CircleCI context. These are fetched in the `deploy_env` job in CircleCI.

Once this is merged, users need to use the MOJ VPN to access the service.