### PR TITLE
Eswe 1744 add employer back journey

### DIFF
--- a/integration_tests/e2e/createJob.cy.ts
+++ b/integration_tests/e2e/createJob.cy.ts
@@ -8,6 +8,7 @@ import JobHowToApplyPage from '../pages/jobs/jobContractHowToApply'
 import JobReviewPage from '../pages/jobs/jobReview'
 import IndexPage from '../pages'
 import JobListPage from '../pages/jobs/jobList'
+import EmployerUpdatePage from '../pages/employers/employerUpdate'
 
 context('Sign In', () => {
   beforeEach(() => {
@@ -884,6 +885,57 @@ context('Sign In', () => {
       // CLick 'add job' again. This should load a new blank job role page, and should not display previously filled-in data.
       jobListPage.addJobButton().click()
       jobRoleUpdatePage.jobTitleField().should('have.value', '')
+    })
+  })
+
+  it("Create job - back button on the ‘add an employer' page", () => {
+    // check broker iteration to allow title change in test
+    cy.checkFeatureToggle('brokerIterationEnabled', isEnabled => {
+      cy.wrap(isEnabled).as('brokerIterationEnabled')
+    })
+
+    cy.get('@brokerIterationEnabled').then(brokerIterationEnabled => {
+      const expectedTitle = brokerIterationEnabled ? 'Manage jobs and employers' : 'Add jobs and employers'
+
+      const jobListPage = new JobListPage(expectedTitle)
+
+      cy.visit('/jobs')
+      jobListPage.addJobButton().click()
+      const jobRoleUpdatePage = new JobRoleUpdatePage('Job role and source')
+
+      // Fill in the job role and source page
+      jobRoleUpdatePage.headerCaption().contains('Add a job - step 1 of 6')
+
+      cy.contains('add the employer')
+        .should('have.attr', 'href')
+        .then(href => {
+          // Optional: assert `from` param exists
+          expect(href).to.include('/employers/employer/new/form/add')
+          expect(href).to.include('from=')
+
+          cy.contains('add the employer')
+          // Expand details properly
+          cy.get('details summary').contains('The employer is not listed').click()
+
+          // Ensure it's open
+          cy.get('details').should('have.attr', 'open')
+
+          // Now safely interact with the link
+          cy.get('[data-qa="add-employer-link"]')
+            .should('be.visible')
+            .should('have.attr', 'href')
+            .and('include', 'from=')
+
+          cy.get('[data-qa="add-employer-link"]').click()
+
+          // Assert redirected to employer add page
+          cy.url().should('include', '/employers/employer/new/form/add')
+
+          const employerUpdatePage = new EmployerUpdatePage('Employer details')
+          employerUpdatePage.backLink().click()
+
+          jobRoleUpdatePage.headerCaption().contains('Add a job - step 1 of 6')
+        })
     })
   })
 })

--- a/server/app.ts
+++ b/server/app.ts
@@ -28,6 +28,7 @@ import sanitizeQuery from './middleware/sanitizeQuery'
 import { appInsightsMiddleware } from './utils/azureAppInsights'
 import config from './config'
 import logger from '../logger'
+import navigationMiddleware from './middleware/navigationMiddleware'
 
 export default function createApp(services: Services, applicationInfo: ApplicationInfo): express.Application {
   const app = express()
@@ -66,6 +67,7 @@ export default function createApp(services: Services, applicationInfo: Applicati
 
   // Check for authorised roles
   app.use(authorisationMiddleware(getAuthorisedRoles()))
+  app.use(navigationMiddleware)
 
   app.use(routes(services))
 

--- a/server/middleware/navigationMiddleware.test.ts
+++ b/server/middleware/navigationMiddleware.test.ts
@@ -1,0 +1,59 @@
+import { Request, Response, NextFunction } from 'express'
+import navigationMiddleware from './navigationMiddleware'
+import { navigationService } from '../services/navigationService'
+
+jest.mock('../services/navigationService', () => ({
+  navigationService: {
+    getBackLink: jest.fn(),
+    appendFromParam: jest.fn(),
+  },
+}))
+
+describe('navigationMiddleware', () => {
+  let req: Partial<Request>
+  let res: Partial<Response>
+  let next: NextFunction
+
+  beforeEach(() => {
+    req = {
+      originalUrl: '/current/page',
+    }
+
+    res = {
+      locals: {},
+    }
+
+    next = jest.fn()
+
+    jest.clearAllMocks()
+  })
+
+  it('sets res.locals.backLink using navigationService', () => {
+    ;(navigationService.getBackLink as jest.Mock).mockReturnValue('/previous')
+
+    navigationMiddleware(req as Request, res as Response, next)
+
+    expect(navigationService.getBackLink).toHaveBeenCalledWith('/current/page')
+    expect(res.locals.backLink).toBe('/previous')
+  })
+
+  it('adds withFrom helper to res.locals', () => {
+    ;(navigationService.getBackLink as jest.Mock).mockReturnValue('/previous')
+    ;(navigationService.appendFromParam as jest.Mock).mockReturnValue('/target?from=encrypted')
+
+    navigationMiddleware(req as Request, res as Response, next)
+
+    const result = res.locals.withFrom('/target')
+
+    expect(navigationService.appendFromParam).toHaveBeenCalledWith('/target', '/current/page')
+    expect(result).toBe('/target?from=encrypted')
+  })
+
+  it('calls next()', () => {
+    ;(navigationService.getBackLink as jest.Mock).mockReturnValue('/previous')
+
+    navigationMiddleware(req as Request, res as Response, next)
+
+    expect(next).toHaveBeenCalled()
+  })
+})

--- a/server/middleware/navigationMiddleware.ts
+++ b/server/middleware/navigationMiddleware.ts
@@ -1,0 +1,11 @@
+import { Request, Response, NextFunction } from 'express'
+import { navigationService } from '../services/navigationService'
+
+const navigationMiddleware = (req: Request, res: Response, next: NextFunction) => {
+  res.locals.backLink = navigationService.getBackLink(req.originalUrl)
+
+  res.locals.withFrom = (targetUrl: string) => navigationService.appendFromParam(targetUrl, req.originalUrl)
+
+  next()
+}
+export default navigationMiddleware

--- a/server/services/navigationService.test.ts
+++ b/server/services/navigationService.test.ts
@@ -1,0 +1,100 @@
+import { NavigationService } from './navigationService'
+import { encryptUrlParameter, decryptUrlParameter } from '../utils/urlParameterEncryption'
+
+jest.mock('../utils/urlParameterEncryption')
+
+const mockEncrypt = encryptUrlParameter as jest.Mock
+const mockDecrypt = decryptUrlParameter as jest.Mock
+
+describe('NavigationService', () => {
+  let service: NavigationService
+
+  beforeEach(() => {
+    service = new NavigationService()
+    jest.clearAllMocks()
+  })
+
+  describe('appendFromParam', () => {
+    it('returns targetUrl if currentUrl is undefined', () => {
+      const result = service.appendFromParam('/target')
+
+      expect(result).toBe('/target')
+      expect(mockEncrypt).not.toHaveBeenCalled()
+    })
+
+    it('appends from param when target has no query string', () => {
+      mockEncrypt.mockReturnValue('encryptedValue')
+
+      const result = service.appendFromParam('/target', '/current')
+
+      expect(mockEncrypt).toHaveBeenCalledWith('/current')
+      expect(result).toBe('/target?from=encryptedValue')
+    })
+
+    it('uses & if targetUrl already contains query parameters', () => {
+      mockEncrypt.mockReturnValue('encryptedValue')
+
+      const result = service.appendFromParam('/target?page=1', '/current')
+
+      expect(result).toBe('/target?page=1&from=encryptedValue')
+    })
+
+    it('removes existing from parameter from currentUrl before encrypting', () => {
+      mockEncrypt.mockReturnValue('encryptedValue')
+
+      const result = service.appendFromParam('/target', '/current?from=abc')
+
+      expect(mockEncrypt).toHaveBeenCalledWith('/current')
+      expect(result).toBe('/target?from=encryptedValue')
+    })
+
+    it('preserves other query parameters in currentUrl', () => {
+      mockEncrypt.mockReturnValue('encryptedValue')
+
+      const result = service.appendFromParam('/target', '/current?a=1&b=2')
+
+      expect(mockEncrypt).toHaveBeenCalledWith('/current?a=1&b=2')
+      expect(result).toBe('/target?from=encryptedValue')
+    })
+  })
+
+  describe('getBackLink', () => {
+    it('returns fallback if currentUrl is undefined', () => {
+      const result = service.getBackLink(undefined, '/fallback')
+
+      expect(result).toBe('/fallback')
+    })
+
+    it('returns fallback if from parameter is missing', () => {
+      const result = service.getBackLink('/page?a=1', '/fallback')
+
+      expect(result).toBe('/fallback')
+    })
+
+    it('decrypts and returns the from parameter', () => {
+      mockDecrypt.mockReturnValue('/previous')
+
+      const result = service.getBackLink('/page?from=encryptedValue')
+
+      expect(mockDecrypt).toHaveBeenCalledWith('encryptedValue')
+      expect(result).toBe('/previous')
+    })
+
+    it('works when from parameter is not first query parameter', () => {
+      mockDecrypt.mockReturnValue('/previous')
+
+      const result = service.getBackLink('/page?a=1&from=encryptedValue&b=2')
+
+      expect(mockDecrypt).toHaveBeenCalledWith('encryptedValue')
+      expect(result).toBe('/previous')
+    })
+
+    it('returns fallback when decryption returns null', () => {
+      mockDecrypt.mockReturnValue(null)
+
+      const result = service.getBackLink('/page?from=encryptedValue', '/fallback')
+
+      expect(result).toBe(null) // current implementation behaviour
+    })
+  })
+})

--- a/server/services/navigationService.ts
+++ b/server/services/navigationService.ts
@@ -1,0 +1,48 @@
+import { encryptUrlParameter, decryptUrlParameter } from '../utils/urlParameterEncryption'
+
+const FROM_PARAM = 'from'
+
+export class NavigationService {
+  /**
+   * Build a forward link preserving the current page
+   */
+  appendFromParam(targetUrl: string, currentUrl?: string): string {
+    if (!currentUrl) return targetUrl
+
+    const cleaned = this.removeQueryParam(currentUrl, FROM_PARAM)
+    const encrypted = encryptUrlParameter(cleaned)
+
+    const separator = targetUrl.includes('?') ? '&' : '?'
+
+    return `${targetUrl}${separator}${FROM_PARAM}=${encrypted}`
+  }
+
+  /**
+   * Resolve a back link from the current request
+   */
+  getBackLink(currentUrl?: string, fallback = '/'): string {
+    if (!currentUrl) return fallback
+
+    const match = currentUrl.match(new RegExp(`[?&]${FROM_PARAM}=([^&]+)`))
+    if (!match) return fallback
+
+    const decrypted = decryptUrlParameter(match[1])
+
+    return decrypted
+  }
+
+  /**
+   * Remove a query parameter
+   */
+  private removeQueryParam(url: string, param: string): string {
+    const [path, query] = url.split('?')
+
+    if (!query) return url
+
+    const filtered = query.split('&').filter(q => !q.startsWith(`${param}=`))
+
+    return filtered.length ? `${path}?${filtered.join('&')}` : path
+  }
+}
+
+export const navigationService = new NavigationService()

--- a/server/views/pages/employers/employerUpdate/index.njk
+++ b/server/views/pages/employers/employerUpdate/index.njk
@@ -12,7 +12,7 @@
 {% set title = "Employer details"%}
 
 {% block beforeContent %}
-    {{ govukBackLink({ text: "Back", href: backLocation }) }}
+    {{ govukBackLink({ text: "Back", href: backLink }) }}
 {% endblock %}
 
 {% block content %}

--- a/server/views/pages/jobs/jobRoleUpdate/index.njk
+++ b/server/views/pages/jobs/jobRoleUpdate/index.njk
@@ -41,7 +41,7 @@
           }}
 
           {% set detailsHtml %}
-            <div>You must <a href="{{ addressLookup.employers.employerUpdate('new') }}" class="govuk-link govuk-link--no-visited-state">add the employer</a> before adding a job. Any data you've already entered on this screen will be lost. </div>
+              <div>You must <a href="{{ withFrom(addressLookup.employers.employerUpdate('new')) }}" class="govuk-link govuk-link--no-visited-state">add the employer</a> before adding a job. Any data you've already entered on this screen will be lost. </div>
           {% endset -%}
 
           {{ govukDetails({

--- a/server/views/pages/jobs/jobRoleUpdate/index.njk
+++ b/server/views/pages/jobs/jobRoleUpdate/index.njk
@@ -41,7 +41,7 @@
           }}
 
           {% set detailsHtml %}
-              <div>You must <a href="{{ withFrom(addressLookup.employers.employerUpdate('new')) }}" class="govuk-link govuk-link--no-visited-state">add the employer</a> before adding a job. Any data you've already entered on this screen will be lost. </div>
+              <div>You must <a href="{{ withFrom(addressLookup.employers.employerUpdate('new')) }}" class="govuk-link govuk-link--no-visited-state" data-qa="add-employer-link">add the employer</a> before adding a job. Any data you've already entered on this screen will be lost. </div>
           {% endset -%}
 
           {{ govukDetails({


### PR DESCRIPTION
This pull request ensures that _back button on the ‘add an employer' page should always return to the page the user just came from._ 

It adds:
**Navigation Service & Middleware Implementation:**

* Added a new `NavigationService` in `server/services/navigationService.ts` to manage encrypted "from" parameters in URLs, providing methods for appending and resolving back links.
* Introduced `navigationMiddleware` in `server/middleware/navigationMiddleware.ts` to set `backLink` and `withFrom` helpers on `res.locals` for use in views, and integrated it into the Express app in `server/app.ts`. 