### PR TITLE
ESWE-1817:fix jobTitle header displays special characters

### DIFF
--- a/server/middleware/sanitizeBody.ts
+++ b/server/middleware/sanitizeBody.ts
@@ -2,7 +2,7 @@ import { escape, trim } from 'validator'
 import { Request, Response, NextFunction } from 'express'
 
 // Define a whitelist of fields that should not be sanitized
-const WHITELIST = ['_csrf', 'jobTitleOrEmployerNameFilter', 'employerNameFilter']
+const WHITELIST = ['_csrf', 'jobTitleOrEmployerNameFilter', 'employerNameFilter', 'jobTitle']
 
 const sanitizeBody = (req: Request, res: Response, next: NextFunction): void => {
   const sanitizeField = (value: unknown): string => {

--- a/server/routes/jobs/jobRoleUpdate/jobRoleUpdateController.test.ts
+++ b/server/routes/jobs/jobRoleUpdate/jobRoleUpdateController.test.ts
@@ -139,5 +139,20 @@ describe('jobRoleUpdateController', () => {
 
       expect(res.redirect).toHaveBeenCalledWith(addressLookup.jobs.jobContractUpdate(id))
     })
+
+    it('On success - jobTitle has special chars, sets session and redirects to jobContractUpdate', async () => {
+      req.body.employerId = 'test id'
+      req.body.jobTitle = "test job title's special"
+      req.body.sector = 'OUTDOOR'
+      req.body.industrySector = 'RETAIL'
+      req.body.numberOfVacancies = '1'
+      req.body.sourcePrimary = 'DWP'
+      req.body.sourceSecondary = 'EAB'
+      req.body.charityName = 'Test chrity'
+
+      controller.post(req, res, next)
+
+      expect(res.redirect).toHaveBeenCalledWith(addressLookup.jobs.jobContractUpdate(id))
+    })
   })
 })

--- a/server/views/pages/jobs/jobRoleUpdate/index.njk
+++ b/server/views/pages/jobs/jobRoleUpdate/index.njk
@@ -52,7 +52,7 @@
           {{ govukInput({
               id: "jobTitle",
               name: "jobTitle",
-              value: jobTitle | safe,
+              value: jobTitle,
               type: "text",
               label: {
                 text: "Job title"


### PR DESCRIPTION
This pull request primarily addresses the handling and sanitization of the `jobTitle` field in the job role update flow. The changes ensure that `jobTitle` is properly whitelisted from sanitization, that special characters are handled correctly, and that the field value is rendered safely in the view. 

- Added a test case in `jobRoleUpdateController.test.ts` to verify that when `jobTitle` contains special characters, the session is set and the user is redirected appropriately.

**View Rendering:**
- Updated the `jobTitle` input in the Nunjucks template to remove the `| safe` filter, preventing potential XSS vulnerabilities by ensuring the value is not rendered as raw HTML.