### PR TITLE
ESWE-1886: Update Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,6 +6,7 @@ node_modules
 npm-debug.log
 .*
 !.allowed-scripts.mjs
+!.npmrc
 **/*.test.js
 scss-report.txt
 eslint-report.html

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,41 +1,37 @@
-# Stage: base image
-FROM ghcr.io/ministryofjustice/hmpps-node:24-alpine AS base
-
+# Build args available to all stages
 ARG BUILD_NUMBER
 ARG GIT_REF
 ARG GIT_BRANCH
 
-LABEL maintainer="HMPPS Digital Studio <info@digital.justice.gov.uk>"
+# Stage: build assets
+FROM ghcr.io/ministryofjustice/hmpps-node:24-alpine AS build
+
+ARG BUILD_NUMBER
+ARG GIT_REF
+ARG GIT_BRANCH
 
 # Cache breaking and ensure required build / git args defined
 RUN test -n "$BUILD_NUMBER" || (echo "BUILD_NUMBER not set" && false)
 RUN test -n "$GIT_REF" || (echo "GIT_REF not set" && false)
 RUN test -n "$GIT_BRANCH" || (echo "GIT_BRANCH not set" && false)
 
-# Define env variables for runtime health / info
-ENV BUILD_NUMBER=${BUILD_NUMBER}
-ENV GIT_REF=${GIT_REF}
-ENV GIT_BRANCH=${GIT_BRANCH}
+WORKDIR /app
 
-# Stage: build assets
-FROM base as build
-
-ARG BUILD_NUMBER
-ARG GIT_REF
-ARG GIT_BRANCH
-
-COPY package*.json .allowed-scripts.mjs ./
-RUN CYPRESS_INSTALL_BINARY=0 npm run setup --no-audit
-RUN npm run setup
+COPY package*.json .allowed-scripts.mjs .npmrc ./
+RUN CYPRESS_INSTALL_BINARY=0 NPM_CONFIG_AUDIT=false NPM_CONFIG_FUND=false npm run setup
 ENV NODE_ENV='production'
 
 COPY . .
 RUN npm run build
 
-RUN npm prune --no-audit --omit=dev
+RUN npm prune --no-audit --no-fund --omit=dev
 
 # Stage: copy production assets and dependencies
-FROM base
+FROM ghcr.io/ministryofjustice/hmpps-node:24-alpine-runtime
+
+ARG BUILD_NUMBER
+ARG GIT_REF
+ARG GIT_BRANCH
 
 COPY --from=build --chown=appuser:appgroup \
         /app/package.json \
@@ -52,7 +48,10 @@ COPY --from=build --chown=appuser:appgroup \
         /app/node_modules ./node_modules
 
 EXPOSE 3000 3001
+ENV BUILD_NUMBER=${BUILD_NUMBER}
+ENV GIT_REF=${GIT_REF}
+ENV GIT_BRANCH=${GIT_BRANCH}
 ENV NODE_ENV='production'
 USER 2000
 
-CMD [ "npm", "start" ]
+CMD [ "node", "dist/server.js" ]


### PR DESCRIPTION
Dockerfile:
- Remove npm from final image using new alpine-runtime image.

More at Dockerfile:
- `npm run setup` run once only, not twice.
- Copy `.npmrc` to docker build
- disable npm audit and fund during setup
- remove npm audit from prune command
- disable npm audit during prune command
- disable fund during prune command
- enable build arguments and environment variables