### PR TITLE
ESWE-1913 update duplicate job workflow

### DIFF
--- a/integration_tests/e2e/duplicateJob.cy.ts
+++ b/integration_tests/e2e/duplicateJob.cy.ts
@@ -192,7 +192,7 @@ context('Sign In', () => {
 
     jobDuplicatePage.employerIdLink().click()
     const jobRoleUpdatePage = new JobRoleUpdatePage('Job role and source')
-    jobRoleUpdatePage.headerCaption().contains('Update a job - step 1 of 5')
+    jobRoleUpdatePage.headerCaption().contains('Duplicate a job')
 
     jobRoleUpdatePage.employerIdField().clear().type('Tesco')
     jobRoleUpdatePage.employerIdFieldOption(0).click()
@@ -237,7 +237,7 @@ context('Sign In', () => {
     // Contract page changes
     jobDuplicatePage.postCodeLink().click()
     const jobContractUpdatePage = new JobContractUpdatePage('Job location and contract')
-    jobContractUpdatePage.headerCaption().contains('Update a job - step 2 of 5')
+    jobContractUpdatePage.headerCaption().contains('Duplicate a job')
 
     jobContractUpdatePage.postCodeField().clear().type('NE35 6DR')
     jobContractUpdatePage.submitButton().click()
@@ -291,7 +291,7 @@ context('Sign In', () => {
     // Requirements page changes
     jobDuplicatePage.essentialCriteriaLink().click()
     const jobRequirementsUpdatePage = new JobRequirementsUpdatePage('Requirements and job description')
-    jobContractUpdatePage.headerCaption().contains('Update a job - step 3 of 5')
+    jobRequirementsUpdatePage.headerCaption().contains('Duplicate a job')
 
     jobRequirementsUpdatePage.essentialCriteriaField().clear().type('Some essential text')
     jobRequirementsUpdatePage.submitButton().click()
@@ -317,7 +317,7 @@ context('Sign In', () => {
     // How to apply page changes
     jobDuplicatePage.closingDateLink().click()
     const jobHowToApplyPage = new JobHowToApplyPage('How to apply')
-    jobHowToApplyPage.headerCaption().contains('Update a job - step 4 of 5')
+    jobHowToApplyPage.headerCaption().contains('Duplicate a job')
 
     jobHowToApplyPage.closingDateField.day().clear().type('3')
     jobHowToApplyPage.closingDateField.month().clear().type('4')
@@ -372,7 +372,7 @@ context('Sign In', () => {
 
     jobDuplicatePage.employerIdLink().click()
     const jobRoleUpdatePage = new JobRoleUpdatePage('Job role and source')
-    jobRoleUpdatePage.headerCaption().contains('Update a job - step 1 of 6')
+    jobRoleUpdatePage.headerCaption().contains('Duplicate a job')
 
     jobRoleUpdatePage.employerIdField().clear().type('Tesco')
     jobRoleUpdatePage.employerIdFieldOption(0).click()
@@ -417,7 +417,7 @@ context('Sign In', () => {
     // National job page changes
     jobDuplicatePage.isNationalLink().click()
     const jobIsNationalUpdatePage = new JobIsNationalUpdatePage('Is this a national job?')
-    jobIsNationalUpdatePage.headerCaption().contains('Update a job - step 2 of 6')
+    jobIsNationalUpdatePage.headerCaption().contains('Duplicate a job')
 
     // Non-national to National
     jobIsNationalUpdatePage.isNationalFieldYes().click()
@@ -430,7 +430,7 @@ context('Sign In', () => {
     jobIsNationalUpdatePage.submitButton().click()
     // Should go to the contract page next, for the user to fill in postcode details
     const jobContractUpdatePage = new JobContractUpdatePage('Job location and contract')
-    jobContractUpdatePage.headerCaption().contains('Update a job - step 3 of 6')
+    jobContractUpdatePage.headerCaption().contains('Duplicate a job')
     jobContractUpdatePage.postCodeField().clear().type('NE35 8DR')
     jobContractUpdatePage.submitButton().click()
     jobDuplicatePage.postCode().contains('NE35 8DR')
@@ -490,7 +490,7 @@ context('Sign In', () => {
     // Requirements page changes
     jobDuplicatePage.essentialCriteriaLink().click()
     const jobRequirementsUpdatePage = new JobRequirementsUpdatePage('Requirements and job description')
-    jobContractUpdatePage.headerCaption().contains('Update a job - step 4 of 6')
+    jobRequirementsUpdatePage.headerCaption().contains('Duplicate a job')
 
     jobRequirementsUpdatePage.essentialCriteriaField().clear().type('Some essential text')
     jobRequirementsUpdatePage.submitButton().click()
@@ -516,7 +516,7 @@ context('Sign In', () => {
     // How to apply page changes
     jobDuplicatePage.closingDateLink().click()
     const jobHowToApplyPage = new JobHowToApplyPage('How to apply')
-    jobHowToApplyPage.headerCaption().contains('Update a job - step 5 of 6')
+    jobHowToApplyPage.headerCaption().contains('Duplicate a job')
     jobHowToApplyPage.closingDateField.day().clear().type('3')
     jobHowToApplyPage.closingDateField.month().clear().type('4')
     jobHowToApplyPage.closingDateField.year().clear().type('2027')
@@ -584,7 +584,7 @@ context('Sign In', () => {
       // Update the job details
       jobDuplicatePage.jobTitleLink().click()
       const jobRoleUpdatePage = new JobRoleUpdatePage('Job role and source')
-      jobRoleUpdatePage.headerCaption().contains('Update a job - step 1 of 6')
+      jobRoleUpdatePage.headerCaption().contains('Duplicate a job')
 
       jobRoleUpdatePage.jobTitleField().clear().type('A different job')
       jobRoleUpdatePage.submitButton().click()

--- a/integration_tests/e2e/jobList.cy.ts
+++ b/integration_tests/e2e/jobList.cy.ts
@@ -48,7 +48,7 @@ context('Sign In', () => {
     })
   })
 
-  it('Update job flow', () => {
+  it('Manage job flow', () => {
     cy.checkFeatureToggle('nationalJobs', isEnabled => {
       cy.wrap(isEnabled).as('nationalJobsEnabled')
     })
@@ -64,13 +64,6 @@ context('Sign In', () => {
       jobListPage.jobLink(1).click()
 
       const jobReviewPage = new JobReviewPage('Warehouse operator')
-      cy.get('@nationalJobsEnabled').then(isEnabled => {
-        if (isEnabled) {
-          jobReviewPage.headerCaption().contains('Update a job - step 6 of 6')
-        } else {
-          jobReviewPage.headerCaption().contains('Update a job - step 5 of 5')
-        }
-      })
     })
   })
 

--- a/integration_tests/e2e/updateJob.cy.ts
+++ b/integration_tests/e2e/updateJob.cy.ts
@@ -6,6 +6,7 @@ import JobRequirementsUpdatePage from '../pages/jobs/jobRequirementsUpdate'
 import JobReviewPage from '../pages/jobs/jobReview'
 import JobRoleUpdatePage from '../pages/jobs/jobRoleUpdate'
 import JobIsNationalUpdatePage from '../pages/jobs/jobIsNationalUpdate'
+import JobListPage from '../pages/jobs/jobList'
 
 context('Sign In', () => {
   beforeEach(() => {
@@ -24,17 +25,13 @@ context('Sign In', () => {
       cy.wrap(isEnabled).as('nationalJobsEnabled')
     })
 
-    cy.visit('/jobs/job/0190a227-be75-7009-8ad6-c6b068b6754e/review/update')
+    cy.visit('/jobs/job/0190a227-be75-7009-8ad6-c6b068b6754e/review/manage')
 
     const jobReviewPage = new JobReviewPage('Warehouse operator')
 
-    cy.get('@nationalJobsEnabled').then(isEnabled => {
-      if (isEnabled) {
-        jobReviewPage.headerCaption().contains('Update a job - step 6 of 6')
-      } else {
-        jobReviewPage.headerCaption().contains('Update a job - step 5 of 5')
-      }
-    })
+    jobReviewPage.updateJobButton().click()
+
+    jobReviewPage.headerCaption().contains('Update a job')
 
     jobReviewPage.employerId().contains('ASDA')
     jobReviewPage.jobTitle().contains('Warehouse operator')
@@ -88,10 +85,13 @@ context('Sign In', () => {
 
     cy.task('getNationalJob')
 
-    cy.visit('/jobs/job/0190a227-be75-7009-8ad6-c6b068b6754e/review/update')
+    cy.visit('/jobs/job/0190a227-be75-7009-8ad6-c6b068b6754e/review/manage')
 
     const jobReviewPage = new JobReviewPage('National Warehouse operator')
-    jobReviewPage.headerCaption().contains('Update a job - step 6 of 6')
+
+    jobReviewPage.updateJobButton().click()
+
+    jobReviewPage.headerCaption().contains('Update a job')
 
     jobReviewPage.employerId().contains('ASDA')
     jobReviewPage.jobTitle().contains('Warehouse operator')
@@ -137,14 +137,16 @@ context('Sign In', () => {
 
     cy.task('getJob')
 
-    cy.visit('/jobs/job/0190a227-be75-7009-8ad6-c6b068b6754e/review/update')
+    cy.visit('/jobs/job/0190a227-be75-7009-8ad6-c6b068b6754e/review/manage')
 
     const jobReviewPage = new JobReviewPage('Warehouse operator')
-    jobReviewPage.headerCaption().contains('Update a job - step 5 of 5')
+    jobReviewPage.updateJobButton().click()
+
+    jobReviewPage.headerCaption().contains('Update a job')
 
     jobReviewPage.employerIdLink().click()
     const jobRoleUpdatePage = new JobRoleUpdatePage('Job role and source')
-    jobRoleUpdatePage.headerCaption().contains('Update a job - step 1 of 5')
+    jobRoleUpdatePage.headerCaption().contains('Update a job')
 
     jobRoleUpdatePage.employerIdField().clear().type('Tesco')
     jobRoleUpdatePage.employerIdFieldOption(0).click()
@@ -189,7 +191,7 @@ context('Sign In', () => {
     // Contract page changes
     jobReviewPage.postCodeLink().click()
     const jobContractUpdatePage = new JobContractUpdatePage('Job location and contract')
-    jobContractUpdatePage.headerCaption().contains('Update a job - step 2 of 5')
+    jobContractUpdatePage.headerCaption().contains('Update a job')
 
     jobContractUpdatePage.postCodeField().clear().type('NE35 6DR')
     jobContractUpdatePage.submitButton().click()
@@ -243,7 +245,7 @@ context('Sign In', () => {
     // Requirements page changes
     jobReviewPage.essentialCriteriaLink().click()
     const jobRequirementsUpdatePage = new JobRequirementsUpdatePage('Requirements and job description')
-    jobContractUpdatePage.headerCaption().contains('Update a job - step 3 of 5')
+    jobRequirementsUpdatePage.headerCaption().contains('Update a job')
 
     jobRequirementsUpdatePage.essentialCriteriaField().clear().type('Some essential text')
     jobRequirementsUpdatePage.submitButton().click()
@@ -269,7 +271,7 @@ context('Sign In', () => {
     // How to apply page changes
     jobReviewPage.closingDateLink().click()
     const jobHowToApplyPage = new JobHowToApplyPage('How to apply')
-    jobHowToApplyPage.headerCaption().contains('Update a job - step 4 of 5')
+    jobHowToApplyPage.headerCaption().contains('Update a job')
 
     jobHowToApplyPage.closingDateField.day().clear().type('3')
     jobHowToApplyPage.closingDateField.month().clear().type('4')
@@ -314,14 +316,16 @@ context('Sign In', () => {
     })
     cy.task('getJob')
 
-    cy.visit('/jobs/job/0190a227-be75-7009-8ad6-c6b068b6754e/review/update')
+    cy.visit('/jobs/job/0190a227-be75-7009-8ad6-c6b068b6754e/review/manage')
 
     const jobReviewPage = new JobReviewPage('Warehouse operator')
-    jobReviewPage.headerCaption().contains('Update a job - step 6 of 6')
+    jobReviewPage.updateJobButton().click()
+
+    jobReviewPage.headerCaption().contains('Update a job')
 
     jobReviewPage.employerIdLink().click()
     const jobRoleUpdatePage = new JobRoleUpdatePage('Job role and source')
-    jobRoleUpdatePage.headerCaption().contains('Update a job - step 1 of 6')
+    jobRoleUpdatePage.headerCaption().contains('Update a job')
 
     jobRoleUpdatePage.employerIdField().clear().type('Tesco')
     jobRoleUpdatePage.employerIdFieldOption(0).click()
@@ -366,7 +370,7 @@ context('Sign In', () => {
     // National job page changes
     jobReviewPage.isNationalLink().click()
     const jobIsNationalUpdatePage = new JobIsNationalUpdatePage('Is this a national job?')
-    jobIsNationalUpdatePage.headerCaption().contains('Update a job - step 2 of 6')
+    jobIsNationalUpdatePage.headerCaption().contains('Update a job')
 
     // Non-national to National
     jobIsNationalUpdatePage.isNationalFieldYes().click()
@@ -379,7 +383,7 @@ context('Sign In', () => {
     jobIsNationalUpdatePage.submitButton().click()
     // Should go to the contract page next, for the user to fill in postcode details
     const jobContractUpdatePage = new JobContractUpdatePage('Job location and contract')
-    jobContractUpdatePage.headerCaption().contains('Update a job - step 3 of 6')
+    jobContractUpdatePage.headerCaption().contains('Update a job')
     jobContractUpdatePage.postCodeField().clear().type('NE35 8DR')
     jobContractUpdatePage.submitButton().click()
     jobReviewPage.postCode().contains('NE35 8DR')
@@ -439,7 +443,7 @@ context('Sign In', () => {
     // Requirements page changes
     jobReviewPage.essentialCriteriaLink().click()
     const jobRequirementsUpdatePage = new JobRequirementsUpdatePage('Requirements and job description')
-    jobContractUpdatePage.headerCaption().contains('Update a job - step 4 of 6')
+    jobRequirementsUpdatePage.headerCaption().contains('Update a job')
 
     jobRequirementsUpdatePage.essentialCriteriaField().clear().type('Some essential text')
     jobRequirementsUpdatePage.submitButton().click()
@@ -465,7 +469,7 @@ context('Sign In', () => {
     // How to apply page changes
     jobReviewPage.closingDateLink().click()
     const jobHowToApplyPage = new JobHowToApplyPage('How to apply')
-    jobHowToApplyPage.headerCaption().contains('Update a job - step 5 of 6')
+    jobHowToApplyPage.headerCaption().contains('Update a job')
 
     jobHowToApplyPage.closingDateField.day().clear().type('3')
     jobHowToApplyPage.closingDateField.month().clear().type('4')
@@ -501,5 +505,40 @@ context('Sign In', () => {
     jobHowToApplyPage.submitButton().click()
     jobReviewPage.supportingDocumentationRequired().contains('Disclosure letter')
     jobReviewPage.supportingDocumentationRequired().contains('Some more text')
+  })
+
+  it('Update job - cancel flow', () => {
+    // Skip tests if broker iteration is not enabled
+    cy.checkFeatureToggle('brokerIterationEnabled', isEnabled => {
+      skipOn(!isEnabled)
+    })
+
+    cy.task('getJob')
+
+    const jobListPage = new JobListPage('Manage jobs and employers')
+
+    cy.visit('/jobs')
+    jobListPage.jobLink(1).click()
+    const jobReviewPage = new JobReviewPage('Warehouse operator')
+
+    // Click the update button
+    jobReviewPage.updateJobButton().click()
+
+    // Update the job details
+    jobReviewPage.jobTitleLink().click()
+    const jobRoleUpdatePage = new JobRoleUpdatePage('Job role and source')
+    jobRoleUpdatePage.headerCaption().contains('Update a job')
+
+    jobRoleUpdatePage.jobTitleField().clear().type('A different job')
+    jobRoleUpdatePage.submitButton().click()
+    jobReviewPage.jobTitle().contains('A different job')
+
+    // Cancel the update - return to the jobs list
+    jobReviewPage.cancelButton().click()
+
+    // Select the job again, click the 'Update' button again - previous changes have been lost.
+    jobListPage.jobLink(1).click()
+    jobReviewPage.updateJobButton().click()
+    jobReviewPage.jobTitle().contains('Warehouse operator')
   })
 })

--- a/integration_tests/e2e/updateJob.cy.ts
+++ b/integration_tests/e2e/updateJob.cy.ts
@@ -24,7 +24,7 @@ context('Sign In', () => {
       cy.wrap(isEnabled).as('nationalJobsEnabled')
     })
 
-    cy.visit('/jobs/job/0190a227-be75-7009-8ad6-c6b068b6754e')
+    cy.visit('/jobs/job/0190a227-be75-7009-8ad6-c6b068b6754e/review/update')
 
     const jobReviewPage = new JobReviewPage('Warehouse operator')
 
@@ -88,7 +88,7 @@ context('Sign In', () => {
 
     cy.task('getNationalJob')
 
-    cy.visit('/jobs/job/0190a227-be75-7009-8ad6-c6b068b6754e')
+    cy.visit('/jobs/job/0190a227-be75-7009-8ad6-c6b068b6754e/review/update')
 
     const jobReviewPage = new JobReviewPage('National Warehouse operator')
     jobReviewPage.headerCaption().contains('Update a job - step 6 of 6')
@@ -137,7 +137,7 @@ context('Sign In', () => {
 
     cy.task('getJob')
 
-    cy.visit('/jobs/job/0190a227-be75-7009-8ad6-c6b068b6754e')
+    cy.visit('/jobs/job/0190a227-be75-7009-8ad6-c6b068b6754e/review/update')
 
     const jobReviewPage = new JobReviewPage('Warehouse operator')
     jobReviewPage.headerCaption().contains('Update a job - step 5 of 5')
@@ -314,7 +314,7 @@ context('Sign In', () => {
     })
     cy.task('getJob')
 
-    cy.visit('/jobs/job/0190a227-be75-7009-8ad6-c6b068b6754e')
+    cy.visit('/jobs/job/0190a227-be75-7009-8ad6-c6b068b6754e/review/update')
 
     const jobReviewPage = new JobReviewPage('Warehouse operator')
     jobReviewPage.headerCaption().contains('Update a job - step 6 of 6')

--- a/integration_tests/pages/jobs/jobReview.ts
+++ b/integration_tests/pages/jobs/jobReview.ts
@@ -7,6 +7,10 @@ export default class JobReviewPage extends Page {
 
   duplicateJobButton = (): PageElement => cy.get('[data-qa=duplicate-button]')
 
+  updateJobButton = (): PageElement => cy.get('[data-qa=update-button]')
+
+  cancelButton = (): PageElement => cy.get('[data-qa=cancel-update-button]')
+
   // Values
   employerId = (): PageElement => cy.get('[data-qa=employerId]')
 

--- a/server/routes/addressLookup.ts
+++ b/server/routes/addressLookup.ts
@@ -6,7 +6,7 @@ export default {
   },
   jobs: {
     jobList: () => '/jobs',
-    jobReview: (id: string) => `/jobs/job/${id}`,
+    jobReview: (id: string, mode = 'add') => `/jobs/job/${id}/review/${mode}`,
     jobRoleUpdate: (id: string, mode = 'add') => `/jobs/job/${id}/role/${mode}`,
     jobIsNationalUpdate: (id: string, mode = 'add') => `/jobs/job/${id}/is-this-national-job/${mode}`,
     jobContractUpdate: (id: string, mode = 'add') => `/jobs/job/${id}/contract/${mode}`,

--- a/server/routes/jobs/jobContractUpdate/jobContractUpdateController.ts
+++ b/server/routes/jobs/jobContractUpdate/jobContractUpdateController.ts
@@ -50,7 +50,7 @@ export default class JobContractUpdateController {
         backLocation =
           res.locals.useNationalJobs === true && job.isNationalChanged
             ? addressLookup.jobs.jobIsNationalUpdate(id, mode)
-            : addressLookup.jobs.jobReview(id)
+            : addressLookup.jobs.jobReview(id, mode)
       }
 
       // Render data
@@ -125,7 +125,7 @@ export default class JobContractUpdateController {
       if (mode === modeValue.duplicate) {
         nextPage = addressLookup.jobs.jobDuplicate(id)
       } else if (mode === modeValue.update) {
-        nextPage = addressLookup.jobs.jobReview(id)
+        nextPage = addressLookup.jobs.jobReview(id, mode)
       } else {
         nextPage = addressLookup.jobs.jobRequirementsUpdate(id)
       }

--- a/server/routes/jobs/jobHowToApplyUpdate/jobHowToApplyUpdateController.test.ts
+++ b/server/routes/jobs/jobHowToApplyUpdate/jobHowToApplyUpdateController.test.ts
@@ -151,7 +151,7 @@ describe('jobHowToApplyUpdateController', () => {
 
       controller.post(req, res, next)
 
-      expect(res.redirect).toHaveBeenCalledWith(addressLookup.jobs.jobReview(id))
+      expect(res.redirect).toHaveBeenCalledWith(addressLookup.jobs.jobReview(id, mode))
     })
   })
 })

--- a/server/routes/jobs/jobHowToApplyUpdate/jobHowToApplyUpdateController.ts
+++ b/server/routes/jobs/jobHowToApplyUpdate/jobHowToApplyUpdateController.ts
@@ -37,7 +37,7 @@ export default class jobHowToApplyUpdateController {
       } else if (mode === modeValue.duplicate) {
         backLocation = addressLookup.jobs.jobDuplicate(id)
       } else {
-        backLocation = addressLookup.jobs.jobReview(id)
+        backLocation = addressLookup.jobs.jobReview(id, mode)
       }
 
       // Render data
@@ -116,7 +116,7 @@ export default class jobHowToApplyUpdateController {
 
       // Redirect to next page in flow
       res.redirect(
-        mode === modeValue.duplicate ? addressLookup.jobs.jobDuplicate(id) : addressLookup.jobs.jobReview(id),
+        mode === modeValue.duplicate ? addressLookup.jobs.jobDuplicate(id) : addressLookup.jobs.jobReview(id, mode),
       )
     } catch (err) {
       logger.error('Error posting form - How to apply')

--- a/server/routes/jobs/jobIsNationalUpdate/jobIsNationalUpdateController.ts
+++ b/server/routes/jobs/jobIsNationalUpdate/jobIsNationalUpdateController.ts
@@ -24,7 +24,7 @@ export default class JobIsNationalUpdateController {
       } else if (mode === modeValue.duplicate) {
         backLocation = addressLookup.jobs.jobDuplicate(id)
       } else {
-        backLocation = addressLookup.jobs.jobReview(id)
+        backLocation = addressLookup.jobs.jobReview(id, mode)
       }
       // Render data
       const data = {
@@ -71,7 +71,7 @@ export default class JobIsNationalUpdateController {
         // Changing job from national to regional - need to update postcode info on the contract page.
         nextPage = addressLookup.jobs.jobContractUpdate(id, mode)
       } else if (mode === modeValue.update) {
-        nextPage = addressLookup.jobs.jobReview(id)
+        nextPage = addressLookup.jobs.jobReview(id, mode)
       } else {
         nextPage = addressLookup.jobs.jobDuplicate(id)
       }

--- a/server/routes/jobs/jobRequirementsUpdate/jobRequirementsUpdateController.ts
+++ b/server/routes/jobs/jobRequirementsUpdate/jobRequirementsUpdateController.ts
@@ -32,7 +32,7 @@ export default class JobRequirementsUpdateController {
       } else if (mode === modeValue.duplicate) {
         backLocation = addressLookup.jobs.jobDuplicate(id)
       } else {
-        backLocation = addressLookup.jobs.jobReview(id)
+        backLocation = addressLookup.jobs.jobReview(id, mode)
       }
 
       // Render data
@@ -90,7 +90,7 @@ export default class JobRequirementsUpdateController {
       if (mode === modeValue.duplicate) {
         nextPage = addressLookup.jobs.jobDuplicate(id)
       } else if (mode === modeValue.update) {
-        nextPage = addressLookup.jobs.jobReview(id)
+        nextPage = addressLookup.jobs.jobReview(id, mode)
       } else {
         nextPage = addressLookup.jobs.jobHowToApplysUpdate(id)
       }

--- a/server/routes/jobs/jobReview/index.test.ts
+++ b/server/routes/jobs/jobReview/index.test.ts
@@ -31,7 +31,7 @@ describe('jobReview routes', () => {
     routes(router, services)
 
     expect(router.get).toHaveBeenCalledWith(
-      '/jobs/job/:id',
+      '/jobs/job/:id/review/:mode',
       [
         expect.any(Function), // getJobReviewResolver
         expect.any(Function), // getAllEmployersResolver
@@ -44,7 +44,7 @@ describe('jobReview routes', () => {
     routes(router, services)
 
     expect(router.post).toHaveBeenCalledWith(
-      '/jobs/job/:id',
+      '/jobs/job/:id/review/:mode',
       expect.any(Function), // controller.get
     )
   })

--- a/server/routes/jobs/jobReview/index.ts
+++ b/server/routes/jobs/jobReview/index.ts
@@ -9,10 +9,10 @@ export default (router: Router, services: Services) => {
   const controller = new JobReviewController(services.jobService)
 
   router.get(
-    '/jobs/job/:id',
+    '/jobs/job/:id/review/:mode',
     [getJobReviewResolver(services.jobService), getAllEmployersResolver(services.employerService)],
     controller.get,
   )
 
-  router.post('/jobs/job/:id', controller.post)
+  router.post('/jobs/job/:id/review/:mode', controller.post)
 }

--- a/server/routes/jobs/jobReview/jobReviewController.test.ts
+++ b/server/routes/jobs/jobReview/jobReviewController.test.ts
@@ -69,6 +69,7 @@ describe('JobReviewController', () => {
     employerName: 'ASDA',
     closingDate: '1 February 2025',
     startDate: '31 May 2025',
+    backLocation: '/jobs',
   }
 
   setSessionData(req, ['job', id], job)

--- a/server/routes/jobs/jobReview/jobReviewController.ts
+++ b/server/routes/jobs/jobReview/jobReviewController.ts
@@ -43,6 +43,7 @@ export default class JobReviewController {
       // Render data
       const data = {
         id,
+        mode,
         ...job,
         startDate: job.startDate && formatShortDate(new Date(job.startDate)),
         closingDate: job.closingDate && formatShortDate(new Date(job.closingDate)),
@@ -61,7 +62,7 @@ export default class JobReviewController {
   }
 
   public post: RequestHandler = async (req, res, next): Promise<void> => {
-    const { id } = req.params
+    const { id, mode } = req.params
 
     if (Object.prototype.hasOwnProperty.call(req.body, 'duplicateJobButton')) {
       res.redirect(addressLookup.jobs.jobDuplicate(id))
@@ -76,6 +77,7 @@ export default class JobReviewController {
       if (errors) {
         res.render('pages/jobs/jobReview/index', {
           id,
+          mode,
           ...job,
           employerName: (req.context.allEmployers || []).find((p: { id: string }) => p.id === job.employerId)?.name,
           startDate: job.startDate && formatShortDate(new Date(job.startDate)),

--- a/server/routes/jobs/jobReview/jobReviewController.ts
+++ b/server/routes/jobs/jobReview/jobReviewController.ts
@@ -3,7 +3,7 @@ import { v7 as uuidv7 } from 'uuid'
 import _ from 'lodash'
 
 import { auditService } from '@ministryofjustice/hmpps-audit-client'
-import { deleteSessionData, formatShortDate, getSessionData, setSessionData } from '../../../utils/index'
+import { deleteSessionData, formatShortDate, getSessionData, modeValue, setSessionData } from '../../../utils/index'
 import addressLookup from '../../addressLookup'
 import JobService from '../../../services/jobService'
 import JobSector from '../../../enums/jobSector'
@@ -38,7 +38,7 @@ export default class JobReviewController {
         return
       }
 
-      const errors = validateFormSchema(job, validationSchema())
+      const errors = mode === modeValue.manage ? null : validateFormSchema(job, validationSchema())
 
       // Render data
       const data = {
@@ -49,6 +49,7 @@ export default class JobReviewController {
         closingDate: job.closingDate && formatShortDate(new Date(job.closingDate)),
         employerName: (allEmployers.find((p: { id: string }) => p.id === job.employerId) || {}).name,
         errors,
+        backLocation: addressLookup.jobs.jobList(),
       }
 
       // Set page data in session
@@ -64,8 +65,18 @@ export default class JobReviewController {
   public post: RequestHandler = async (req, res, next): Promise<void> => {
     const { id, mode } = req.params
 
+    if (Object.prototype.hasOwnProperty.call(req.body, 'updateJobButton')) {
+      res.redirect(addressLookup.jobs.jobReview(id, 'update'))
+      return
+    }
     if (Object.prototype.hasOwnProperty.call(req.body, 'duplicateJobButton')) {
       res.redirect(addressLookup.jobs.jobDuplicate(id))
+      return
+    }
+    if (Object.prototype.hasOwnProperty.call(req.body, 'cancelUpdateButton')) {
+      // Clear any unsaved changes made to the job
+      deleteSessionData(req, ['job', id])
+      res.redirect(addressLookup.jobs.jobList())
       return
     }
 

--- a/server/routes/jobs/jobRoleUpdate/jobRoleUpdateController.ts
+++ b/server/routes/jobs/jobRoleUpdate/jobRoleUpdateController.ts
@@ -33,7 +33,7 @@ export default class JobRoleUpdateController {
       } else if (mode === modeValue.duplicate) {
         backLocation = addressLookup.jobs.jobDuplicate(id)
       } else {
-        backLocation = addressLookup.jobs.jobReview(id)
+        backLocation = addressLookup.jobs.jobReview(id, mode)
       }
 
       // Render data
@@ -112,7 +112,7 @@ export default class JobRoleUpdateController {
       } else if (mode === modeValue.duplicate) {
         nextPage = addressLookup.jobs.jobDuplicate(id)
       } else {
-        nextPage = addressLookup.jobs.jobReview(id)
+        nextPage = addressLookup.jobs.jobReview(id, mode)
       }
       res.redirect(nextPage)
     } catch (err) {

--- a/server/utils/mode.ts
+++ b/server/utils/mode.ts
@@ -2,6 +2,7 @@ enum ModeValue {
   add = 'add',
   update = 'update',
   duplicate = 'duplicate',
+  manage = 'manage',
 }
 
 export default ModeValue

--- a/server/views/pages/jobs/jobContractUpdate/index.njk
+++ b/server/views/pages/jobs/jobContractUpdate/index.njk
@@ -18,8 +18,13 @@
 
   <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-
-        <span class="govuk-caption-l" data-qa="headerCaption">{{ 'Add' if mode === 'add' else 'Update' }} a job - step {{ '3 of 6' if useNationalJobs else '2 of 5' }}</span>
+        {% if mode == "duplicate" %}
+          <span class="govuk-caption-l" data-qa="headerCaption">Duplicate a job</span>
+        {% elif id == "new" %}
+          <span class="govuk-caption-l" data-qa="headerCaption">Add a job - step {{ '3 of 6' if useNationalJobs else '2 of 5' }}</span>
+        {% else %}
+           <span class="govuk-caption-l" data-qa="headerCaption">Update a job</span>
+        {% endif %}
         <h1 class="govuk-heading-l">
           {{ title }}
         </h1>

--- a/server/views/pages/jobs/jobDuplicate/index.njk
+++ b/server/views/pages/jobs/jobDuplicate/index.njk
@@ -7,6 +7,7 @@
 {%- from "moj/components/pagination/macro.njk" import mojPagination -%}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "../../../macros/error-summary/macro.njk" import errorSummary %}
+{% from "moj/components/alert/macro.njk" import mojAlert %}
 
 {% block content %}
   {{ errorSummary(errors, "You must fix these problems before updates can be saved") }}
@@ -21,6 +22,7 @@
             html: 'Update the details below before saving.'
           })
       }}
+      <span class="govuk-caption-l" data-qa="headerCaption">Duplicate a job</span>
       <h1 class="govuk-heading-l">
         {{ jobTitle }}
       </h1>

--- a/server/views/pages/jobs/jobDuplicate/index.njk
+++ b/server/views/pages/jobs/jobDuplicate/index.njk
@@ -13,17 +13,14 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
-        <div class="govuk-notification-banner__header">
-          <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
-            Important
-          </h2>
-        </div>
-        <div class="govuk-notification-banner__content">
-          <h3 class="govuk-notification-banner__heading">Duplicating {{ jobTitle }}</h3>
-          <p class="govuk-body">Update the details below before saving.</p>
-        </div>
-      </div>
+      {{ mojAlert({
+            variant: "information",
+            title: "Duplicating " + jobTitle,
+            showTitleAsHeading: true,
+            dismissible: false,
+            html: 'Update the details below before saving.'
+          })
+      }}
       <h1 class="govuk-heading-l">
         {{ jobTitle }}
       </h1>

--- a/server/views/pages/jobs/jobHowToApplyUpdate/index.njk
+++ b/server/views/pages/jobs/jobHowToApplyUpdate/index.njk
@@ -21,8 +21,13 @@
 
   <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-
-        <span class="govuk-caption-l" data-qa="headerCaption">{{ 'Add' if mode === 'add' else 'Update' }} a job - step {{ '5 of 6' if useNationalJobs else '4 of 5' }}</span>
+        {% if mode == "duplicate" %}
+          <span class="govuk-caption-l" data-qa="headerCaption">Duplicate a job</span>
+        {% elif id == "new" %}
+          <span class="govuk-caption-l" data-qa="headerCaption">Add a job - step {{ '5 of 6' if useNationalJobs else '4 of 5' }}</span>
+        {% else %}
+           <span class="govuk-caption-l" data-qa="headerCaption">Update a job</span>
+        {% endif %}
         <h1 class="govuk-heading-l">
           {{ title }}
         </h1>

--- a/server/views/pages/jobs/jobIsNationalUpdate/index.njk
+++ b/server/views/pages/jobs/jobIsNationalUpdate/index.njk
@@ -21,8 +21,13 @@
 
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
-
-            <span class="govuk-caption-l" data-qa="headerCaption">{{ 'Add' if mode === 'add' else 'Update' }} a job - step 2 of 6</span>
+        {% if mode == "duplicate" %}
+          <span class="govuk-caption-l" data-qa="headerCaption">Duplicate a job</span>
+        {% elif id == "new" %}
+          <span class="govuk-caption-l" data-qa="headerCaption">Add a job - step 2 of 6 }}</span>
+        {% else %}
+           <span class="govuk-caption-l" data-qa="headerCaption">Update a job</span>
+        {% endif %}
             <h1 class="govuk-heading-l">
                 {{ title }}
             </h1>

--- a/server/views/pages/jobs/jobList/partials/_jobListTable.njk
+++ b/server/views/pages/jobs/jobList/partials/_jobListTable.njk
@@ -46,7 +46,7 @@
             {% for item in jobs %}
                 <tr class="govuk-table__row {{ rowClass.next() }}">
                     <td class="govuk-table__cell" width="25%">
-                        <a href="{{ addressLookup.jobs.jobReview(item.id, 'update') }}"
+                        <a href="{{ addressLookup.jobs.jobReview(item.id, 'manage') }}"
                            rel="noopener noreferrer"
                            data-qa="quick-look-link"
                            aria-label="Job link for {{ item.jobTitle  }}"

--- a/server/views/pages/jobs/jobRequirementsUpdate/index.njk
+++ b/server/views/pages/jobs/jobRequirementsUpdate/index.njk
@@ -19,8 +19,13 @@
 
   <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-
-        <span class="govuk-caption-l" data-qa="headerCaption">{{ 'Add' if mode === 'add' else 'Update' }} a job - step {{ '4 of 6' if useNationalJobs else '3 of 5' }}</span>
+        {% if mode == "duplicate" %}
+          <span class="govuk-caption-l" data-qa="headerCaption">Duplicate a job</span>
+        {% elif id == "new" %}
+          <span class="govuk-caption-l" data-qa="headerCaption">Add a job - step {{ '4 of 6' if useNationalJobs else '3 of 5' }}</span>
+        {% else %}
+           <span class="govuk-caption-l" data-qa="headerCaption">Update a job</span>
+        {% endif %}
         <h1 class="govuk-heading-l">
           {{ title }}
         </h1>

--- a/server/views/pages/jobs/jobReview/index.njk
+++ b/server/views/pages/jobs/jobReview/index.njk
@@ -7,6 +7,7 @@
 {%- from "moj/components/pagination/macro.njk" import mojPagination -%}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "../../../macros/error-summary/macro.njk" import errorSummary %}
+{% from "moj/components/alert/macro.njk" import mojAlert %}
 
 {% set title = "Check your answers before adding job" if id === 'new' else jobTitle %}
 
@@ -19,20 +20,20 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <span class="govuk-caption-l" data-qa="headerCaption">{{ 'Add' if id === 'new' else 'Update' }} a job - step {{ '6 of 6' if useNationalJobs else '5 of 5' }}</span>
-      {% if brokerIterationEnabled === true and id !== 'new' %}
-      <form class="form" method="post" novalidate="">
-        <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
-          {{ govukButton({
-            text: "Duplicate job",
-            id: "duplicateJobButton",
-            name: "duplicateJobButton",
-            classes: "govuk-button govuk-button--secondary button-float-right",
-            attributes: {
-              "data-qa": "duplicate-button"
-            }
-          }) }}
-        </form>
+        {% if mode == "update" and id != "new" %}
+            {{ mojAlert({
+                  variant: "information",
+                  title: "Updating " + jobTitle,
+                  showTitleAsHeading: true,
+                  dismissible: false,
+                  html: 'Update the details below before saving.'
+                })
+            }}
+        {% endif %}
+      {% if id == "new" %}
+        <span class="govuk-caption-l" data-qa="headerCaption">Add a job - step {{ '6 of 6' if useNationalJobs else '5 of 5' }}</span>
+      {% elif mode == "update" %}
+        <span class="govuk-caption-l" data-qa="headerCaption">Update a job</span>
       {% endif %}
       <h1 class="govuk-heading-l">
         {{ title }}
@@ -51,17 +52,56 @@
       {% include './partials/_howToApplySection.njk' %}
 
       <form class="form" method="post" novalidate="">
-        <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
-        {{  
-          govukButton({
-            text: "Add job and save" if id === 'new' else "Update job and save" ,
-            type: "submit",
-            attributes: {
-              "data-qa": "submit-button",
-              "data-ga-category": "submit-selected-data"
-            }
-          }) 
-        }}
+        {% if mode == "manage" %}
+            <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+            {{
+              govukButton({
+                text: "Update job" ,
+                id: "updateJobButton",
+                name: "updateJobButton",
+                classes: "govuk-button",
+                attributes: {
+                  "data-qa": "update-button"
+                }
+              })
+            }}
+        {% else %}
+            <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+            {{
+              govukButton({
+                text: "Add job and save" if id == "new" else "Update job and save" ,
+                type: "submit",
+                attributes: {
+                  "data-qa": "submit-button",
+                  "data-ga-category": "submit-selected-data"
+                }
+              })
+            }}
+        {% endif %}
+        {% if brokerIterationEnabled === true and mode == "manage" %}
+            <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+              {{ govukButton({
+                text: "Duplicate job",
+                id: "duplicateJobButton",
+                name: "duplicateJobButton",
+                classes: "govuk-button govuk-button--secondary",
+                attributes: {
+                  "data-qa": "duplicate-button"
+                }
+              }) }}
+        {% endif %}
+        {% if mode == "update" and id != "new" %}
+            <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+              {{ govukButton({
+                text: "Cancel and return to jobs list",
+                id: "cancelUpdateButton",
+                name: "cancelUpdateButton",
+                classes: "govuk-button govuk-button--secondary",
+                attributes: {
+                  "data-qa": "cancel-update-button"
+                }
+              }) }}
+        {% endif %}
       </form>
     </div>
   </div>

--- a/server/views/pages/jobs/jobReview/index.njk
+++ b/server/views/pages/jobs/jobReview/index.njk
@@ -12,7 +12,9 @@
 {% set title = "Check your answers before adding job" if id === 'new' else jobTitle %}
 
 {% block beforeContent %}
-
+    {% if mode == "manage" %}
+        {{ govukBackLink({ text: "Back", href: backLocation }) }}
+    {% endif %}
 {% endblock %}
 
 {% block content %}
@@ -52,8 +54,8 @@
       {% include './partials/_howToApplySection.njk' %}
 
       <form class="form" method="post" novalidate="">
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
         {% if mode == "manage" %}
-            <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
             {{
               govukButton({
                 text: "Update job" ,
@@ -66,7 +68,6 @@
               })
             }}
         {% else %}
-            <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
             {{
               govukButton({
                 text: "Add job and save" if id == "new" else "Update job and save" ,
@@ -79,7 +80,6 @@
             }}
         {% endif %}
         {% if brokerIterationEnabled === true and mode == "manage" %}
-            <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
               {{ govukButton({
                 text: "Duplicate job",
                 id: "duplicateJobButton",
@@ -91,7 +91,6 @@
               }) }}
         {% endif %}
         {% if mode == "update" and id != "new" %}
-            <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
               {{ govukButton({
                 text: "Cancel and return to jobs list",
                 id: "cancelUpdateButton",

--- a/server/views/pages/jobs/jobReview/partials/_contractSection.njk
+++ b/server/views/pages/jobs/jobReview/partials/_contractSection.njk
@@ -8,11 +8,13 @@
         <dd class="govuk-summary-list__value" data-qa="postCode">
           {{ postCode }}
         </dd>
-        <dd class="govuk-summary-list__actions">
-          <a class="govuk-link" href="{{ addressLookup.jobs.jobContractUpdate(id, 'update') + '#postCode' }}" data-qa="postCodeLink">
-            Change<span class="govuk-visually-hidden"> job location</span>
-          </a>
-        </dd>
+        {% if mode !== "manage" %}
+            <dd class="govuk-summary-list__actions">
+              <a class="govuk-link" href="{{ addressLookup.jobs.jobContractUpdate(id, 'update') + '#postCode' }}" data-qa="postCodeLink">
+                Change<span class="govuk-visually-hidden"> job location</span>
+              </a>
+            </dd>
+        {% endif %}
       </div>
   {% endif %}
   <div class="govuk-summary-list__row">
@@ -22,11 +24,13 @@
     <dd class="govuk-summary-list__value" data-qa="salaryFrom">
       £{{ salaryFrom | fixed }}
     </dd>
-    <dd class="govuk-summary-list__actions">
-      <a class="govuk-link" href="{{ addressLookup.jobs.jobContractUpdate(id, 'update') + '#salaryFrom' }}" data-qa="salaryFromLink">
-        Change<span class="govuk-visually-hidden"> salary from</span>
-      </a>
-    </dd>
+    {% if mode !== "manage" %}
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="{{ addressLookup.jobs.jobContractUpdate(id, 'update') + '#salaryFrom' }}" data-qa="salaryFromLink">
+            Change<span class="govuk-visually-hidden"> salary from</span>
+          </a>
+        </dd>
+    {% endif %}
   </div>
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">
@@ -35,11 +39,13 @@
     <dd class="govuk-summary-list__value" data-qa="salaryTo">
       {{ ('£'+(salaryTo | fixed)) if salaryTo else 'Not provided' }}
     </dd>
-    <dd class="govuk-summary-list__actions">
-      <a class="govuk-link" href="{{ addressLookup.jobs.jobContractUpdate(id, 'update') + '#salaryTo' }}" data-qa="salaryToLink">
-        Change<span class="govuk-visually-hidden"> salary to (optional)</span>
-      </a>
-    </dd>
+    {% if mode !== "manage" %}
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="{{ addressLookup.jobs.jobContractUpdate(id, 'update') + '#salaryTo' }}" data-qa="salaryToLink">
+            Change<span class="govuk-visually-hidden"> salary to (optional)</span>
+          </a>
+        </dd>
+    {% endif %}
   </div>
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">
@@ -48,11 +54,13 @@
     <dd class="govuk-summary-list__value" data-qa="salaryPeriod">
       {{ contentLookup.salaryPeriod[salaryPeriod] }}
     </dd>
-    <dd class="govuk-summary-list__actions">
-      <a class="govuk-link" href="{{ addressLookup.jobs.jobContractUpdate(id, 'update') + '#salaryPeriod' }}" data-qa="salaryPeriodLink">
-        Change<span class="govuk-visually-hidden"> salary period</span>
-      </a>
-    </dd>
+    {% if mode !== "manage" %}
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="{{ addressLookup.jobs.jobContractUpdate(id, 'update') + '#salaryPeriod' }}" data-qa="salaryPeriodLink">
+            Change<span class="govuk-visually-hidden"> salary period</span>
+          </a>
+        </dd>
+    {% endif %}
   </div>
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">
@@ -61,11 +69,13 @@
     <dd class="govuk-summary-list__value" data-qa="additionalSalaryInformation">
       {{ (additionalSalaryInformation | safe) if additionalSalaryInformation else 'Not provided' }}
     </dd>
-    <dd class="govuk-summary-list__actions">
-      <a class="govuk-link" href="{{ addressLookup.jobs.jobContractUpdate(id, 'update') + '#additionalSalaryInformation' }}" data-qa="additionalSalaryInformationLink">
-        Change<span class="govuk-visually-hidden"> additional salary information  (optional)</span>
-      </a>
-    </dd>
+    {% if mode !== "manage" %}
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="{{ addressLookup.jobs.jobContractUpdate(id, 'update') + '#additionalSalaryInformation' }}" data-qa="additionalSalaryInformationLink">
+            Change<span class="govuk-visually-hidden"> additional salary information  (optional)</span>
+          </a>
+        </dd>
+    {% endif %}
   </div>
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">
@@ -74,11 +84,13 @@
     <dd class="govuk-summary-list__value" data-qa="isPayingAtLeastNationalMinimumWage">
       {{ contentLookup.yesNo[isPayingAtLeastNationalMinimumWage] }}
     </dd>
-    <dd class="govuk-summary-list__actions">
-      <a class="govuk-link" href="{{ addressLookup.jobs.jobContractUpdate(id, 'update') + '#isPayingAtLeastNationalMinimumWage' }}" data-qa="isPayingAtLeastNationalMinimumWageLink">
-        Change<span class="govuk-visually-hidden"> pays at least minimum wage?</span>
-      </a>
-    </dd>
+    {% if mode !== "manage" %}
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="{{ addressLookup.jobs.jobContractUpdate(id, 'update') + '#isPayingAtLeastNationalMinimumWage' }}" data-qa="isPayingAtLeastNationalMinimumWageLink">
+            Change<span class="govuk-visually-hidden"> pays at least minimum wage?</span>
+          </a>
+        </dd>
+    {% endif %}
   </div>
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">
@@ -87,11 +99,13 @@
     <dd class="govuk-summary-list__value" data-qa="workPattern">
       {{ contentLookup.workPattern[workPattern] }}
     </dd>
-    <dd class="govuk-summary-list__actions">
-      <a class="govuk-link" href="{{ addressLookup.jobs.jobContractUpdate(id, 'update') + '#workPattern' }}" data-qa="workPatternLink">
-        Change<span class="govuk-visually-hidden"> work pattern</span>
-      </a>
-    </dd>
+    {% if mode !== "manage" %}
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="{{ addressLookup.jobs.jobContractUpdate(id, 'update') + '#workPattern' }}" data-qa="workPatternLink">
+            Change<span class="govuk-visually-hidden"> work pattern</span>
+          </a>
+        </dd>
+    {% endif %}
   </div>
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">
@@ -100,11 +114,13 @@
     <dd class="govuk-summary-list__value" data-qa="hoursPerWeek">
       {{ contentLookup.hours[hoursPerWeek] }}
     </dd>
-    <dd class="govuk-summary-list__actions">
-      <a class="govuk-link" href="{{ addressLookup.jobs.jobContractUpdate(id, 'update') + '#hoursPerWeek' }}" data-qa="hoursPerWeekLink">
-        Change<span class="govuk-visually-hidden"> hours per week</span>
-      </a>
-    </dd>
+    {% if mode !== "manage" %}
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="{{ addressLookup.jobs.jobContractUpdate(id, 'update') + '#hoursPerWeek' }}" data-qa="hoursPerWeekLink">
+            Change<span class="govuk-visually-hidden"> hours per week</span>
+          </a>
+        </dd>
+    {% endif %}
   </div>
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">
@@ -113,11 +129,13 @@
     <dd class="govuk-summary-list__value" data-qa="contractType">
       {{ contentLookup.contractType[contractType] }}
     </dd>
-    <dd class="govuk-summary-list__actions">
-      <a class="govuk-link" href="{{ addressLookup.jobs.jobContractUpdate(id, 'update') + '#contractType' }}" data-qa="contractTypeLink">
-        Change<span class="govuk-visually-hidden"> contract type</span>
-      </a>
-    </dd>
+    {% if mode !== "manage" %}
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="{{ addressLookup.jobs.jobContractUpdate(id, 'update') + '#contractType' }}" data-qa="contractTypeLink">
+            Change<span class="govuk-visually-hidden"> contract type</span>
+          </a>
+        </dd>
+    {% endif %}
   </div>
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">
@@ -126,10 +144,12 @@
     <dd class="govuk-summary-list__value" data-qa="baseLocation">
       {{ contentLookup.baseLocation[baseLocation] if baseLocation else 'Not provided' }}
     </dd>
-    <dd class="govuk-summary-list__actions">
-      <a class="govuk-link" href="{{ addressLookup.jobs.jobContractUpdate(id, 'update') + '#baseLocation' }}" data-qa="baseLocationLink">
-        Change<span class="govuk-visually-hidden"> base location (optional)</span>
-      </a>
-    </dd>
+    {% if mode !== "manage" %}
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="{{ addressLookup.jobs.jobContractUpdate(id, 'update') + '#baseLocation' }}" data-qa="baseLocationLink">
+            Change<span class="govuk-visually-hidden"> base location (optional)</span>
+          </a>
+        </dd>
+    {% endif %}
   </div>
 </dl>

--- a/server/views/pages/jobs/jobReview/partials/_howToApplySection.njk
+++ b/server/views/pages/jobs/jobReview/partials/_howToApplySection.njk
@@ -7,11 +7,13 @@
     <dd class="govuk-summary-list__value" data-qa="isRollingOpportunity">
       {{ contentLookup.yesNo[isRollingOpportunity] }}
     </dd>
-    <dd class="govuk-summary-list__actions">
-      <a class="govuk-link" href="{{ addressLookup.jobs.jobHowToApplysUpdate(id, 'update') + '#isRollingOpportunity' }}" data-qa="isRollingOpportunityLink">
-        Change<span class="govuk-visually-hidden"> rolling opportunity?</span>
-      </a>
-    </dd>
+    {% if mode !== "manage" %}
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="{{ addressLookup.jobs.jobHowToApplysUpdate(id, 'update') + '#isRollingOpportunity' }}" data-qa="isRollingOpportunityLink">
+            Change<span class="govuk-visually-hidden"> rolling opportunity?</span>
+          </a>
+        </dd>
+    {% endif %}
   </div>
   {% if isRollingOpportunity === 'NO' %}
     <div class="govuk-summary-list__row">
@@ -21,11 +23,13 @@
       <dd class="govuk-summary-list__value" data-qa="closingDate">
         {{ closingDate }}
       </dd>
-      <dd class="govuk-summary-list__actions">
-        <a class="govuk-link" href="{{ addressLookup.jobs.jobHowToApplysUpdate(id, 'update') + '#closingDate' }}" data-qa="closingDateLink">
-          Change<span class="govuk-visually-hidden"> closing date</span>
-        </a>
-      </dd>
+      {% if mode !== "manage" %}
+          <dd class="govuk-summary-list__actions">
+            <a class="govuk-link" href="{{ addressLookup.jobs.jobHowToApplysUpdate(id, 'update') + '#closingDate' }}" data-qa="closingDateLink">
+              Change<span class="govuk-visually-hidden"> closing date</span>
+            </a>
+          </dd>
+      {% endif %}
     </div>
   {% endif %}
   <div class="govuk-summary-list__row">
@@ -35,11 +39,13 @@
     <dd class="govuk-summary-list__value" data-qa="isOnlyForPrisonLeavers">
       {{ contentLookup.yesNo[isOnlyForPrisonLeavers] }}
     </dd>
-    <dd class="govuk-summary-list__actions">
-      <a class="govuk-link" href="{{ addressLookup.jobs.jobHowToApplysUpdate(id, 'update') + '#isOnlyForPrisonLeavers' }}" data-qa="isOnlyForPrisonLeaversLink">
-        Change<span class="govuk-visually-hidden"> job only for prison leavers?</span>
-      </a>
-    </dd>
+    {% if mode !== "manage" %}
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="{{ addressLookup.jobs.jobHowToApplysUpdate(id, 'update') + '#isOnlyForPrisonLeavers' }}" data-qa="isOnlyForPrisonLeaversLink">
+            Change<span class="govuk-visually-hidden"> job only for prison leavers?</span>
+          </a>
+        </dd>
+    {% endif %}
   </div>
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">
@@ -48,11 +54,13 @@
     <dd class="govuk-summary-list__value" data-qa="startDate">
       {{ startDate if startDate else 'Not provided' }}
     </dd>
-    <dd class="govuk-summary-list__actions">
-      <a class="govuk-link" href="{{ addressLookup.jobs.jobHowToApplysUpdate(id, 'update') + '#startDate' }}" data-qa="startDateLink">
-        Change<span class="govuk-visually-hidden"> job start date (optional)</span>
-      </a>
-    </dd>
+    {% if mode !== "manage" %}
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="{{ addressLookup.jobs.jobHowToApplysUpdate(id, 'update') + '#startDate' }}" data-qa="startDateLink">
+            Change<span class="govuk-visually-hidden"> job start date (optional)</span>
+          </a>
+        </dd>
+    {% endif %}
   </div>
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">
@@ -61,11 +69,13 @@
     <dd class="govuk-summary-list__value" data-qa="howToApply">
       {{ howToApply | nl2br | safe }}
     </dd>
-    <dd class="govuk-summary-list__actions">
-      <a class="govuk-link" href="{{ addressLookup.jobs.jobHowToApplysUpdate(id, 'update') + '#howToApply' }}" data-qa="howToApplyLink">
-        Change<span class="govuk-visually-hidden"> how to apply</span>
-      </a>
-    </dd>
+    {% if mode !== "manage" %}
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="{{ addressLookup.jobs.jobHowToApplysUpdate(id, 'update') + '#howToApply' }}" data-qa="howToApplyLink">
+            Change<span class="govuk-visually-hidden"> how to apply</span>
+          </a>
+        </dd>
+    {% endif %}
   </div>
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">
@@ -80,10 +90,12 @@
         Not provided
       {% endif %}
     </dd>
-    <dd class="govuk-summary-list__actions">
-      <a class="govuk-link" href="{{ addressLookup.jobs.jobHowToApplysUpdate(id, 'update') + '#supportingDocumentationRequired' }}" data-qa="supportingDocumentationRequiredLink">
-        Change<span class="govuk-visually-hidden"> supporting documentation required</span>
-      </a>
-    </dd>
+    {% if mode !== "manage" %}
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="{{ addressLookup.jobs.jobHowToApplysUpdate(id, 'update') + '#supportingDocumentationRequired' }}" data-qa="supportingDocumentationRequiredLink">
+            Change<span class="govuk-visually-hidden"> supporting documentation required</span>
+          </a>
+        </dd>
+    {% endif %}
   </div>
 </dl>

--- a/server/views/pages/jobs/jobReview/partials/_isNationalSection.njk
+++ b/server/views/pages/jobs/jobReview/partials/_isNationalSection.njk
@@ -7,10 +7,12 @@
     <dd class="govuk-summary-list__value" data-qa="isNational">
       {{ contentLookup.yesNo[isNational] }}
     </dd>
-    <dd class="govuk-summary-list__actions">
-      <a class="govuk-link" href="{{ addressLookup.jobs.jobIsNationalUpdate(id, 'update') + '#isNational' }}" data-qa="isNationalLink">
-        Change<span class="govuk-visually-hidden"> national job?</span>
-      </a>
-    </dd>
+    {% if mode !== "manage" %}
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="{{ addressLookup.jobs.jobIsNationalUpdate(id, 'update') + '#isNational' }}" data-qa="isNationalLink">
+            Change<span class="govuk-visually-hidden"> national job?</span>
+          </a>
+        </dd>
+    {% endif %}
   </div>
 </dl>

--- a/server/views/pages/jobs/jobReview/partials/_requirementsSection.njk
+++ b/server/views/pages/jobs/jobReview/partials/_requirementsSection.njk
@@ -7,11 +7,13 @@
     <dd class="govuk-summary-list__value" data-qa="essentialCriteria">
       {{ essentialCriteria | nl2br | safe }}
     </dd>
-    <dd class="govuk-summary-list__actions">
-      <a class="govuk-link" href="{{ addressLookup.jobs.jobRequirementsUpdate(id, 'update') + '#essentialCriteria' }}" data-qa="essentialCriteriaLink">
-        Change<span class="govuk-visually-hidden"> essential job criteria</span>
-      </a>
-    </dd>
+    {% if mode !== "manage" %}
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="{{ addressLookup.jobs.jobRequirementsUpdate(id, 'update') + '#essentialCriteria' }}" data-qa="essentialCriteriaLink">
+            Change<span class="govuk-visually-hidden"> essential job criteria</span>
+          </a>
+        </dd>
+    {% endif %}
   </div>
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">
@@ -20,11 +22,13 @@
     <dd class="govuk-summary-list__value" data-qa="desirableCriteria">
       {{ (desirableCriteria | nl2br | safe) if desirableCriteria else 'Not provided'}}
     </dd>
-    <dd class="govuk-summary-list__actions">
-      <a class="govuk-link" href="{{ addressLookup.jobs.jobRequirementsUpdate(id, 'update') + '#desirableCriteria' }}" data-qa="desirableCriteriaLink">
-        Change<span class="govuk-visually-hidden"> desirable job criteria (optional)</span>
-      </a>
-    </dd>
+    {% if mode !== "manage" %}
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="{{ addressLookup.jobs.jobRequirementsUpdate(id, 'update') + '#desirableCriteria' }}" data-qa="desirableCriteriaLink">
+            Change<span class="govuk-visually-hidden"> desirable job criteria (optional)</span>
+          </a>
+        </dd>
+    {% endif %}
   </div>
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">
@@ -33,11 +37,13 @@
     <dd class="govuk-summary-list__value" data-qa="description">
       {{ description | nl2br | safe }}
     </dd>
-    <dd class="govuk-summary-list__actions">
-      <a class="govuk-link" href="{{ addressLookup.jobs.jobRequirementsUpdate(id, 'update') + '#description' }}" data-qa="descriptionLink">
-        Change<span class="govuk-visually-hidden"> job description</span>
-      </a>
-    </dd>
+    {% if mode !== "manage" %}
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="{{ addressLookup.jobs.jobRequirementsUpdate(id, 'update') + '#description' }}" data-qa="descriptionLink">
+            Change<span class="govuk-visually-hidden"> job description</span>
+          </a>
+        </dd>
+    {% endif %}
   </div>
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key {% if errors.offenceExclusionsDetails %}govuk-summary-list__key--invalid{% endif %}">
@@ -53,10 +59,12 @@
         <div>{{ contentLookup.offenceExclusions[item] }}{{ ' - ' + (offenceExclusionsDetails | nl2br | safe) if item === 'OTHER' }}{{ ',' if offenceExclusions.length !== loop.index }}</div>
       {% endfor %}
     </dd>
-    <dd class="govuk-summary-list__actions">
-      <a class="govuk-link" href="{{ addressLookup.jobs.jobRequirementsUpdate(id, 'update') + '#offenceExclusions' }}" data-qa="offenceExclusionsLink">
-        Change<span class="govuk-visually-hidden"> offence exclusions</span>
-      </a>
-    </dd>
+    {% if mode !== "manage" %}
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="{{ addressLookup.jobs.jobRequirementsUpdate(id, 'update') + '#offenceExclusions' }}" data-qa="offenceExclusionsLink">
+            Change<span class="govuk-visually-hidden"> offence exclusions</span>
+          </a>
+        </dd>
+    {% endif %}
   </div>
 </dl>

--- a/server/views/pages/jobs/jobReview/partials/_roleSection.njk
+++ b/server/views/pages/jobs/jobReview/partials/_roleSection.njk
@@ -7,11 +7,13 @@
     <dd class="govuk-summary-list__value" data-qa="employerId">
       {{ employerName }}
     </dd>
-    <dd class="govuk-summary-list__actions">
-      <a class="govuk-link" href="{{ addressLookup.jobs.jobRoleUpdate(id, 'update') + '#employerId' }}" data-qa="employerIdLink">
-        Change<span class="govuk-visually-hidden"> employer name</span>
-      </a>
-    </dd>
+    {% if mode !== "manage" %}
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="{{ addressLookup.jobs.jobRoleUpdate(id, 'update') + '#employerId' }}" data-qa="employerIdLink">
+            Change<span class="govuk-visually-hidden"> employer name</span>
+          </a>
+        </dd>
+    {% endif %}
   </div>
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">
@@ -20,11 +22,13 @@
     <dd class="govuk-summary-list__value" data-qa="jobTitle">
       {{ jobTitle | safe }}
     </dd>
-    <dd class="govuk-summary-list__actions">
-      <a class="govuk-link" href="{{ addressLookup.jobs.jobRoleUpdate(id, 'update') + '#jobTitle' }}" data-qa="jobTitleLink">
-        Change<span class="govuk-visually-hidden"> job title</span>
-      </a>
-    </dd>
+    {% if mode !== "manage" %}
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="{{ addressLookup.jobs.jobRoleUpdate(id, 'update') + '#jobTitle' }}" data-qa="jobTitleLink">
+            Change<span class="govuk-visually-hidden"> job title</span>
+          </a>
+        </dd>
+    {% endif %}
   </div>
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">
@@ -33,11 +37,13 @@
     <dd class="govuk-summary-list__value" data-qa="sector">
       {{ contentLookup.jobSector[sector] }}
     </dd>
-    <dd class="govuk-summary-list__actions">
-      <a class="govuk-link" href="{{ addressLookup.jobs.jobRoleUpdate(id, 'update') + '#sector' }}" data-qa="sectorLink">
-        Change<span class="govuk-visually-hidden"> job sector</span>
-      </a>
-    </dd>
+    {% if mode !== "manage" %}
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="{{ addressLookup.jobs.jobRoleUpdate(id, 'update') + '#sector' }}" data-qa="sectorLink">
+            Change<span class="govuk-visually-hidden"> job sector</span>
+          </a>
+        </dd>
+    {% endif %}
   </div>
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">
@@ -46,11 +52,13 @@
     <dd class="govuk-summary-list__value" data-qa="industrySector">
       {{ contentLookup.employerSector[industrySector] }}
     </dd>
-    <dd class="govuk-summary-list__actions">
-      <a class="govuk-link" href="{{ addressLookup.jobs.jobRoleUpdate(id, 'update') + '#industrySector' }}" data-qa="industrySectorLink">
-        Change<span class="govuk-visually-hidden"> HMPPS reporting industry sector</span>
-      </a>
-    </dd>
+    {% if mode !== "manage" %}
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="{{ addressLookup.jobs.jobRoleUpdate(id, 'update') + '#industrySector' }}" data-qa="industrySectorLink">
+            Change<span class="govuk-visually-hidden"> HMPPS reporting industry sector</span>
+          </a>
+        </dd>
+    {% endif %}
   </div>
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">
@@ -66,12 +74,13 @@
         {{ numberOfVacancies }}
       </dd>
     {% endif %}
-
-    <dd class="govuk-summary-list__actions">
-      <a class="govuk-link" href="{{ addressLookup.jobs.jobRoleUpdate(id, 'update') + '#numberOfVacancies' }}" data-qa="numberOfVacanciesLink">
-        Change<span class="govuk-visually-hidden"> number of vacancies</span>
-      </a>
-    </dd>
+    {% if mode !== "manage" %}
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="{{ addressLookup.jobs.jobRoleUpdate(id, 'update') + '#numberOfVacancies' }}" data-qa="numberOfVacanciesLink">
+            Change<span class="govuk-visually-hidden"> number of vacancies</span>
+          </a>
+        </dd>
+    {% endif %}
   </div>
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">
@@ -80,11 +89,13 @@
     <dd class="govuk-summary-list__value" data-qa="sourcePrimary">
       {{ contentLookup.jobSource[sourcePrimary] }}
     </dd>
-    <dd class="govuk-summary-list__actions">
-      <a class="govuk-link" href="{{ addressLookup.jobs.jobRoleUpdate(id, 'update') + '#sourcePrimary' }}" data-qa="sourcePrimaryLink">
-        Change<span class="govuk-visually-hidden"> job source</span>
-      </a>
-    </dd>
+    {% if mode !== "manage" %}
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="{{ addressLookup.jobs.jobRoleUpdate(id, 'update') + '#sourcePrimary' }}" data-qa="sourcePrimaryLink">
+            Change<span class="govuk-visually-hidden"> job source</span>
+          </a>
+        </dd>
+    {% endif %}
   </div>
   <div class="govuk-summary-list__row" id="sourceSecondary">
     <dt class="govuk-summary-list__key {% if errors.sourceSecondary %}govuk-summary-list__key--invalid{% endif %}">
@@ -98,11 +109,13 @@
         {% endif %}
       {{ contentLookup.jobSource[sourceSecondary] if sourceSecondary else 'Not provided' }}
     </dd>
-    <dd class="govuk-summary-list__actions">
-      <a class="govuk-link" href="{{ addressLookup.jobs.jobRoleUpdate(id, 'update') + '#sourceSecondary' }}" data-qa="sourceSecondaryLink">
-        Change<span class="govuk-visually-hidden"> job source 2 (optional)</span>
-      </a>
-    </dd>
+    {% if mode !== "manage" %}
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="{{ addressLookup.jobs.jobRoleUpdate(id, 'update') + '#sourceSecondary' }}" data-qa="sourceSecondaryLink">
+            Change<span class="govuk-visually-hidden"> job source 2 (optional)</span>
+          </a>
+        </dd>
+    {% endif %}
   </div>
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">
@@ -111,10 +124,12 @@
     <dd class="govuk-summary-list__value" data-qa="charityName">
       {{ (charityName | safe) if charityName else 'Not provided'}}
     </dd>
-    <dd class="govuk-summary-list__actions">
-      <a class="govuk-link" href="{{ addressLookup.jobs.jobRoleUpdate(id, 'update') + '#charityName' }}" data-qa="charityNameLink">
-        Change<span class="govuk-visually-hidden"> supported by a charity? (optional)</span>
-      </a>
-    </dd>
+    {% if mode !== "manage" %}
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="{{ addressLookup.jobs.jobRoleUpdate(id, 'update') + '#charityName' }}" data-qa="charityNameLink">
+            Change<span class="govuk-visually-hidden"> supported by a charity? (optional)</span>
+          </a>
+        </dd>
+    {% endif %}
   </div>
 </dl>

--- a/server/views/pages/jobs/jobRoleUpdate/index.njk
+++ b/server/views/pages/jobs/jobRoleUpdate/index.njk
@@ -19,8 +19,13 @@
 
   <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-
-        <span class="govuk-caption-l" data-qa="headerCaption">{{ 'Add' if mode === 'add' else 'Update' }} a job - step {{ '1 of 6' if useNationalJobs else '1 of 5' }}</span>
+        {% if mode == "duplicate" %}
+          <span class="govuk-caption-l" data-qa="headerCaption">Duplicate a job</span>
+        {% elif id == "new" %}
+          <span class="govuk-caption-l" data-qa="headerCaption">Add a job - step {{ '1 of 6' if useNationalJobs else '1 of 5' }}</span>
+        {% else %}
+           <span class="govuk-caption-l" data-qa="headerCaption">Update a job</span>
+        {% endif %}
         <h1 class="govuk-heading-l">
           {{ title }}
         </h1>


### PR DESCRIPTION
Update workflow for updating and duplicating jobs:

- Update jobReview page to add a new 'manage' mode. This page now has 3 possible modes: 
    - **add**: CYA page with change links back to modify content while adding a new job. 
    - **manage**: read-only view of an existing job, with buttons to enter the update or duplicate job flows. 
    - **update**: CYA page with change links to modify content for an existing job, and a new button to cancel out of the journey and return to the jobs list. Alert panel at the top indicating that we're updating a job.
- Update headings on all the add/update/duplicate job pages to indicate what's happening.
- Duplicate job flow is unchanged. Notification panel changed to an alert panel, indicating that we're duplicating a job.