### PR TITLE
ESWE-1977: Do not force upgrade connections to HTTPS unless in production

### DIFF
--- a/server/middleware/setUpWebSecurity.ts
+++ b/server/middleware/setUpWebSecurity.ts
@@ -44,6 +44,7 @@ export default function setUpWebSecurity(): Router {
           ],
           fontSrc: ["'self'", config.apis.frontendComponents.url],
           formAction: [`'self' ${config.apis.hmppsAuth.externalUrl}`],
+          ...(config.production ? {} : { upgradeInsecureRequests: null }),
           connectSrc: [
             '*.google-analytics.com',
             '*.googletagmanager.com',


### PR DESCRIPTION
Assets can be downloaded properly to browser, and thus styles can be applied properly.