### PR TITLE
ESWE-2015: Fixed broken test in jobViewModel.test

### DIFF
--- a/server/viewModels/jobViewModel.test.ts
+++ b/server/viewModels/jobViewModel.test.ts
@@ -57,7 +57,10 @@ describe('JobViewModel', () => {
   })
 
   it('should return LIVE status if closingDate is not set', () => {
-    const job = plainToClass(JobViewModel, baseData)
+    const job = plainToClass(JobViewModel, {
+      ...baseData,
+      closingDate: undefined,
+    })
     expect(job.jobStatus).toBe(JobStatus.LIVE)
   })
 


### PR DESCRIPTION
- Updated test 'should return LIVE status if closingDate is not set' to explicitly set closingDate: undefined. 